### PR TITLE
Cli enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+lib


### PR DESCRIPTION
Hi !

First, thank you for your work, it's the simplest sloc utility I found that works as I expected.
I did not touched anything in sloc.coffee, but I wanted to propose you some enhancement in cli.coffee:
- handle recursively files in subdirectories
- display a detailed result per file (with -v/--verbose option), notably file errors
- handle a regular expression exclusion pattern (with -e/--exclude). Sorry, it's not a glob, but rather a Javascript regex.

The file structure changed a lot, I'm sorry for that. Test seems fine on travis, but I'll add new specific test later: I works on windows at home, and buster does not work on it. So I'll test it at work.

Thank you !
