### PR TITLE
Changed order of define/exports/window.

### DIFF
--- a/lib/sloc.js
+++ b/lib/sloc.js
@@ -150,10 +150,10 @@ Copyright 2012 - 2014 (c) Markus Kohlhase <mail@markus-kohlhase.de>
     define(function() {
       return slocModule;
     });
-  } else if (typeof window !== "undefined" && window !== null) {
-    window.sloc = slocModule;
   } else if ((typeof module !== "undefined" && module !== null ? module.exports : void 0) != null) {
     module.exports = slocModule;
+  } else if (typeof window !== "undefined" && window !== null) {
+    window.sloc = slocModule;
   }
 
 }).call(this);

--- a/src/sloc.coffee
+++ b/src/sloc.coffee
@@ -188,10 +188,10 @@ slocModule = (code, lang) ->
 if define?.amd?
   define -> slocModule
 
-# Browser support
-else if window?
-  window.sloc = slocModule
-
 # Node.js support
 else if module?.exports?
   module.exports = slocModule
+
+# Browser support
+else if window?
+  window.sloc = slocModule


### PR DESCRIPTION
I was testing the sloc module within Atom but noticed it always returned an empty `Object {}`.
I guess this is due to the fact that there is a window object present, however, packages should still use `module.exports`. Changing the order of appearance, the module works as expected.
