### PR TITLE
package.json optimizations

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "files": [
     "bin",
     "lib"
-  ]
+  ],
   "scripts": {
     "prepublish": "coffee -c -o lib/ src/",
     "test": "mocha --reporter spec --compilers coffee:coffee-script/register --recursive spec/"


### PR DESCRIPTION
`bin` and `lib` paths are already relative to the package.json file.

`bin` only needs to be an object if the executable name differs from `name` or when supplying multiple names.

`files` makes `npm install --production` installs much lighter.

`scripts` don't need to target executables directly as they are added to `PATH` during `npm install`.
