### PR TITLE
Adding C# support (.cs)

### DIFF
--- a/src/sloc.coffee
+++ b/src/sloc.coffee
@@ -26,7 +26,7 @@ getCommentExpressions = (lang) ->
 
       when "coffee", "py", "ls", "nix", "r", "rb", "jl", "pl"
         /\#/
-      when "js", "c", "cc", "cpp", "h", "hpp", "hx", "ino", "java", "php", \
+      when "js", "c", "cc", "cpp", "cs", "h", "hpp", "hx", "ino", "java", "php", \
            "php5", "go", "scss", "less", "rs", "styl", "scala", "swift", "ts"
         /\/{2}/
       when "lua", "hs"
@@ -45,7 +45,7 @@ getCommentExpressions = (lang) ->
     when "coffee"
       start = stop = /\#{3}/
 
-    when "js", "c", "cc", "cpp", "h", "hpp", "hx", "ino", "java", "ls", "nix", \
+    when "js", "c", "cc", "cpp", "cs", "h", "hpp", "hx", "ino", "java", "ls", "nix", \
          "php", "php5", "go", "css", "scss", "less", "rs", "styl", "scala", "ts"
       start = /\/\*+/
       stop  = /\*\/{1}/
@@ -188,6 +188,7 @@ slocModule.extensions = [
   "clj"
   "coffee"
   "cpp"
+  "cs"
   "css"
   "erl"
   "go"


### PR DESCRIPTION
I added a .cs file extension. C# has single line and block comments.  I tested against a directory with only .css files to make sure I didn't make a regression and it looked fine.   

Also, I tested against a large directory with both .cs and .css files and it reported the correct number of .cs and .css files, so file extension matching doesn't seem to have been negatively affected for .css files.
