### PR TITLE
Support for Objective-C and Objective-C++

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - new supported languages
   - Mochi
+  - Objective-C
+  - Objective-C++
 
 ## v0.1.9
 

--- a/README.markdown
+++ b/README.markdown
@@ -253,6 +253,8 @@ type for all files in the project.
 - Scala
 - SVG
 - Swift
+- Objective-C
+- Objective-C++
 - Typescript
 - Visual Basic
 - Yaml

--- a/spec/languages.coffee
+++ b/spec/languages.coffee
@@ -646,4 +646,21 @@ module.exports =
       mixed: 1
       empty: 0
     }
+    {
+      names: ["m", "mm"]
+      code:
+        """
+          // comment
+          NSLog("foo"); // comment
+
+          /* block comment */
+        """
+      comment: 3
+      source: 1
+      block: 1
+      total: 4
+      single: 2
+      mixed: 1
+      empty: 1
+    }
   ]

--- a/src/sloc.coffee
+++ b/src/sloc.coffee
@@ -27,8 +27,8 @@ getCommentExpressions = (lang) ->
       when "coffee", "py", "ls", "mochi", "nix", "r", "rb", "jl", "pl", \
            "yaml", "hr"
         /\#/
-      when "js", "c", "cc", "cpp", "cs", "h", "hpp", "hx", "ino", "java", \
-           "php", "php5", "go", "groovy", "scss", "less", "rs", "styl", \
+      when "js", "c", "cc", "cpp", "cs", "h", "m", "mm", "hpp", "hx", "ino", \
+           "java", "php", "php5", "go", "groovy", "scss", "less", "rs", "styl", \
             "scala", "swift", "ts", "jade"
         /\/{2}/
       when "lua", "hs"
@@ -47,9 +47,9 @@ getCommentExpressions = (lang) ->
     when "coffee"
       start = stop = /\#{3}/
 
-    when "js", "c", "cc", "cpp", "cs", "h", "hpp", "hx", "ino", "java", "ls", \
-         "nix", "php", "php5", "go", "groovy", "css", "scss", "less", "rs", \
-         "styl", "scala", "ts"
+    when "js", "c", "cc", "cpp", "cs", "h", "m", "mm", "hpp", "hx", "ino", \
+         "java", "ls", "nix", "php", "php5", "go", "groovy", "css", "scss", \
+         "less", "rs", "styl", "scala", "ts"
       start = /\/\*+/
       stop  = /\*\/{1}/
 
@@ -248,6 +248,8 @@ extensions = [
   "vb"
   "xml"
   "yaml"
+  "m"
+  "mm"
 ]
 
 slocModule.extensions = extensions

--- a/src/sloc.coffee
+++ b/src/sloc.coffee
@@ -28,8 +28,8 @@ getCommentExpressions = (lang) ->
            "yaml", "hr"
         /\#/
       when "js", "c", "cc", "cpp", "cs", "h", "m", "mm", "hpp", "hx", "ino", \
-           "java", "php", "php5", "go", "groovy", "scss", "less", "rs", "styl", \
-            "scala", "swift", "ts", "jade"
+           "java", "php", "php5", "go", "groovy", "scss", "less", "rs", \
+            "styl", "scala", "swift", "ts", "jade"
         /\/{2}/
       when "lua", "hs"
         /--/


### PR DESCRIPTION
Objective-C = `.m`
Objective-C++ `.mm`

Both use:

Single line: `//`
Block: `/* */`
