### PR TITLE
Adding support for Google Apps Script's JavaScript extension (.gs)

### DIFF
--- a/spec/languages.coffee
+++ b/spec/languages.coffee
@@ -25,7 +25,7 @@ module.exports =
       empty: 1
     }
     {
-      names: ["js", "ts"]
+      names: ["js", "ts", "gs"]
       code:
         """
           /* a */

--- a/src/sloc.coffee
+++ b/src/sloc.coffee
@@ -29,7 +29,7 @@ getCommentExpressions = (lang) ->
         /\#/
       when "js", "c", "cc", "cpp", "cs", "h", "m", "mm", "hpp", "hx", "ino", \
            "java", "php", "php5", "go", "groovy", "scss", "less", "rs", \
-            "styl", "scala", "swift", "ts", "jade"
+            "styl", "scala", "swift", "ts", "jade", "gs"
         /\/{2}/
       when "lua", "hs"
         /--/
@@ -49,7 +49,7 @@ getCommentExpressions = (lang) ->
 
     when "js", "c", "cc", "cpp", "cs", "h", "m", "mm", "hpp", "hx", "ino", \
          "java", "ls", "nix", "php", "php5", "go", "groovy", "css", "scss", \
-         "less", "rs", "styl", "scala", "ts"
+         "less", "rs", "styl", "scala", "ts", "gs"
       start = /\/\*+/
       stop  = /\*\/{1}/
 
@@ -212,6 +212,7 @@ extensions = [
   "erl"
   "go"
   "groovy"
+  "gs"
   "h"
   "handlebars", "hbs"
   "hpp"


### PR DESCRIPTION
Google Apps Script uses .gs as an extention for JavaScript files. Adding .gs as an alias for .js.