### PR TITLE
Fixing a small bug in the alias handling code

### DIFF
--- a/src/cli.coffee
+++ b/src/cli.coffee
@@ -96,6 +96,8 @@ programm.parse process.argv
 options.keys    = programm.keys
 options.details = programm.details
 options.alias   = programm.alias
+for k of options.alias
+  exts.push "*.#{k}"
 
 return programm.help() if programm.args.length < 1
 


### PR DESCRIPTION
Adding an alias properly substituted the correct language parser, but there is still a file filter that used only the known list of extensions. Added any alias to the extension list.