### PR TITLE
fix #48

### DIFF
--- a/src/formatters/simple.coffee
+++ b/src/formatters/simple.coffee
@@ -21,9 +21,6 @@ stat = (data, options) ->
 
 module.exports = (data, options={}, fmtOpts) ->
 
-  if options.keys?.length is 1 and not options.reportDetails
-    return data.summary[options.keys[0]]
-
   if not options.keys?
     options.keys = sloc.keys
 


### PR DESCRIPTION
`if options.keys?.length is 1 and not options.reportDetails` is not necessary and was introduced in some refactoring (https://github.com/flosse/sloc/commit/fe70a54fa0187454a16e95088188ef8db85d8151).
Either delete this block (as in this pull request), or change it to `if options.keys?.length is 1 and not options.details`. (Second option would only output one number without any further information. Which would be different from the normal behaviour)  
Thanks!