### PR TITLE
Add asm support

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -219,6 +219,7 @@ type for all files in the project.
 
 ## Supported languages
 
+- Assembly
 - CoffeeScript
 - C / C++
 - C#

--- a/spec/languages.coffee
+++ b/spec/languages.coffee
@@ -746,4 +746,26 @@ module.exports =
       mixed: 2
       empty: 1
     }
+    {
+      names: ["asm"]
+      code:
+        """
+          global start
+
+          start:; entry point
+            push rbp
+            mov rsp, rbp
+            ;at&t syntax: ; weird
+            mov %rsp, %rax
+            pop rax
+            ret
+        """
+      total: 9
+      source: 7
+      comment: 2
+      single: 2
+      block: 0
+      mixed: 1
+      empty: 1
+    }
   ]

--- a/src/sloc.coffee
+++ b/src/sloc.coffee
@@ -55,7 +55,7 @@ getCommentExpressions = (lang) ->
           ///
         r._matchGroup_ = 1 # dirty fix
         r
-      when "rkt", "clj", "cljs", "hy"
+      when "rkt", "clj", "cljs", "hy", "asm"
         /;/
       else null
 
@@ -242,6 +242,7 @@ slocModule = (code, lang, opt={}) ->
   { total, source, comment, single, block, mixed, empty }
 
 extensions = [
+  "asm"
   "c"
   "cc"
   "clj"


### PR DESCRIPTION
Most assemblers support `;` as a comment marker, but multiline comments are far from standardised. Some assemblers (notably, nasm) don't support them at all as far as I can tell. This is to enable at least support for counting lines in assembly files using the standard `;` comment marker.