### PR TITLE
fix #48: don't count interpolated strings in coffeescript as comments 

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -219,7 +219,7 @@ type for all files in the project.
 
 ## Supported languages
 
-- CoffeeScript
+- CoffeeScript / IcedCoffeeScript
 - C / C++
 - C#
 - Clojure / ClojureScript
@@ -234,7 +234,6 @@ type for all files in the project.
 - Haxe
 - Hilbert
 - hy
-- IcedCoffeeScript
 - Java
 - JavaScript
 - JSX

--- a/spec/languages.coffee
+++ b/spec/languages.coffee
@@ -5,23 +5,19 @@ module.exports =
       code:
         """
           # a
+          code()
           source.code() # comment
 
           ### block
           comment # commented comment
           ###
-          source() ### one line block ###
-          ### one line block ### code()
-          ### block ### code() ###
-          ### souce() # comment ### no block ###
-          ###### code() ###### code()
         """
-      comment: 10
-      source: 6
-      single: 3
-      block: 8
-      total: 11
-      mixed: 6
+      comment: 5
+      source: 2
+      single: 2
+      block: 3
+      total: 7
+      mixed: 1
       empty: 1
     }
     {

--- a/spec/languages.coffee
+++ b/spec/languages.coffee
@@ -7,16 +7,17 @@ module.exports =
           # a
           code()
           source.code() # comment
+          source.code "\#{interpolation}"
 
           ### block
           comment # commented comment
           ###
         """
       comment: 5
-      source: 2
+      source: 3
       single: 2
       block: 3
-      total: 7
+      total: 8
       mixed: 1
       empty: 1
     }

--- a/spec/sloc.spec.coffee
+++ b/spec/sloc.spec.coffee
@@ -34,19 +34,19 @@ describe "The sloc module", ->
           res = sloc l.code, n
           (n in sloc.extensions).should.equal true
           if l.total
-            res.total   .should.equal l.total
+            res.total   .should.equal l.total,   "Total"
           if l.source
-            res.source  .should.equal l.source
+            res.source  .should.equal l.source,  "Source"
           if l.comment
-            res.comment .should.equal l.comment
+            res.comment .should.equal l.comment, "Comment"
           if l.single
-            res.single  .should.equal l.single
+            res.single  .should.equal l.single,  "Single"
           if l.block
-            res.block   .should.equal l.block
+            res.block   .should.equal l.block,   "Block"
           if l.empty
-            res.empty   .should.equal l.empty
+            res.empty   .should.equal l.empty,   "Empty"
           if l.mixed
-            res.mixed   .should.equal l.mixed
+            res.mixed   .should.equal l.mixed,   "Mixed"
 
   it "should throw an error", ->
     (-> sloc "foo", "foobar").should.throw()

--- a/src/sloc.coffee
+++ b/src/sloc.coffee
@@ -24,8 +24,9 @@ getCommentExpressions = (lang) ->
   single =
     switch lang
 
-      when "coffee", "iced", "cr", "py", "ls", "mochi", "nix", "r", "rb", \
-           "jl", "pl", "yaml", "hr"
+      when "coffee", "iced"
+        /\#[^\{]/ # hashtag not followed by opening curly brace
+      when "cr", "py", "ls", "mochi", "nix", "r", "rb", "jl", "pl", "yaml", "hr"
         /\#/
       when "js", "jsx", "c", "cc", "cpp", "cs", "cxx", "h", "m", "mm", "hpp", \
            "hx", "hxx", "ino", "java", "php", "php5", "go", "groovy", "scss", \


### PR DESCRIPTION
What still doesn't work is a hashtag in a string like `code "words # more"`. This still matches as 'mixed', but that's another issue...

**edit:** Caveat: When a comment starts with `#{` it is ignored. This can happen when commenting out an object literal, but this is an edge case, while interpolation is not.