### PR TITLE
Adding support for Brightscript

### DIFF
--- a/src/sloc.coffee
+++ b/src/sloc.coffee
@@ -37,7 +37,7 @@ getCommentExpressions = (lang) ->
         /--/
       when "erl"
         /\%/
-      when "monkey", "vb"
+      when "brs", "monkey", "vb"
         /'/
       when "nim"
         r =
@@ -245,6 +245,7 @@ slocModule = (code, lang, opt={}) ->
 
 extensions = [
   "asm"
+  "brs"
   "c"
   "cc"
   "clj"


### PR DESCRIPTION
The Brightscript is the language created by Roku to allow create channels for their streaming devices:
https://sdkdocs.roku.com/display/sdkdoc/BrightScript+Language+Reference

It's a type of VisualBasic