### PR TITLE
fix: too many files in system cli error

### DIFF
--- a/src/cli.coffee
+++ b/src/cli.coffee
@@ -115,7 +115,7 @@ readDir = (dir, done) ->
 
   readdirp { root: dir, fileFilter: exts }, (err, res) ->
     return done(err) if err
-    async.map (filterFiles res.files), processFile, done
+    async.mapLimit (filterFiles res.files), 1000, processFile, done
 
 readSource = (p, done) ->
   fs.lstat p, (err, stats) ->


### PR DESCRIPTION
- fixes error "(libuv) kqueue(): Too many open files in system"
- resolves #83