### PR TITLE
"Fix" for Consistency check #90

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Create stats of your source code:
 - lines with single-line comments
 - lines with block comments
 - lines mixed up with source and comments
+- empty lines within block comments
 - empty lines
 - lines with TODO's
 

--- a/spec/sloc.spec.coffee
+++ b/spec/sloc.spec.coffee
@@ -16,14 +16,15 @@ describe "The sloc module", ->
 
   it "should handle CRLF line endings", ->
     sloc("a\r\nb\r\nc", "js").should.eql
-      block:    0
-      comment:  0
-      empty:    0
-      mixed:    0
-      single:   0
-      source:   3
-      todo:     0
-      total:    3
+      block:      0
+      blockEmpty: 0
+      comment:    0
+      empty:      0
+      mixed:      0
+      single:     0
+      source:     3
+      todo:       0
+      total:      3
 
   it "should handle CR line endings", ->
     sloc("a\rb\rc", "js").total.should.equal 3

--- a/spec/sloc.spec.coffee
+++ b/spec/sloc.spec.coffee
@@ -70,6 +70,7 @@ describe "The sloc module", ->
       'single'
       'block'
       'mixed'
+      'blockEmpty'
       'empty'
       'todo']
     sloc.keys.should.be.an 'array'

--- a/src/formatters/simple.coffee
+++ b/src/formatters/simple.coffee
@@ -44,4 +44,4 @@ module.exports = (data, options={}, fmtOpts) ->
 
     result += d.join ''
 
-  result += "\n\n------------------------------\n"
+  result += "\n\n----------------------------\n"

--- a/src/i18n.coffee
+++ b/src/i18n.coffee
@@ -1,13 +1,14 @@
 module.exports =
   en:
-    total   : "Physical"
-    source  : "Source"
-    comment : "Comment"
-    single  : "Single-line comment"
-    block   : "Block comment"
-    mixed   : "Mixed"
-    empty   : "Empty"
-    todo    : "To Do"
+    total      : "Physical"
+    source     : "Source"
+    comment    : "Comment"
+    single     : "Single-line comment"
+    block      : "Block comment"
+    blockEmpty : "Empty block comment"
+    mixed      : "Mixed"
+    empty      : "Empty"
+    todo       : "To Do"
 
     Result    : "Result"
     Path      : "Path"

--- a/src/sloc.coffee
+++ b/src/sloc.coffee
@@ -4,13 +4,14 @@ Copyright 2012 - 2017 (c) Markus Kohlhase <mail@markus-kohlhase.de>
 ###
 
 keys = [
-  'total'     # physical lines of code
-  'source'    # lines of source
-  'comment'   # lines with comments
-  'single'    # lines with single-line comments
-  'block'     # lines with block comments
-  'mixed'     # lines mixed up with source and comments
-  'empty'     # empty lines
+  'total'      # physical lines of code
+  'source'     # lines of source
+  'comment'    # lines with comments
+  'single'     # lines with single-line comments
+  'block'      # lines with block comments
+  'mixed'      # lines mixed up with source and comments
+  'blockEmpty' # empty lines with a block comment
+  'empty'      # empty lines
   'todo'
   ]
 
@@ -246,7 +247,7 @@ slocModule = (code, lang, opt={}) ->
   console.log res if opt.debug
 
   # result
-  { total, source, comment, single, block, mixed, empty, todo }
+  { total, source, comment, single, block, mixed, empty, todo, blockEmpty }
 
 extensions = [
   "asm"


### PR DESCRIPTION
Now reports the number of empty lines with block comments.

Goes from 
```
---------- Result ------------

            Physical :  333
              Source :  262
             Comment :  39
 Single-line comment :  35
       Block comment :  4
               Mixed :  25
               Empty :  57
               To Do :  1

Number of files read :  1

------------------------------
```
to
```
---------- Result ------------

            Physical :  333
              Source :  262
             Comment :  39
 Single-line comment :  35
       Block comment :  4
               Mixed :  25
 Empty block comment :  0
               Empty :  57
               To Do :  1

Number of files read :  1

----------------------------
```

Closes #90

