### PR TITLE
Added MJS support

### DIFF
--- a/src/sloc.coffee
+++ b/src/sloc.coffee
@@ -33,8 +33,8 @@ getCommentExpressions = (lang) ->
         /\#/
       when "js", "jsx", "mjs", "c", "cc", "cpp", "cs", "cxx", "h", "m", "mm", \
            "hpp", "hx", "hxx", "ino", "java", "php", "php5", "go", "groovy", \
-           "scss", "less", "rs", "sass", "styl", "scala", "swift", "ts", "jade", \
-           "gs", "nut", "kt", "kts", "tsx", "fs", "fsi", "fsx", "bsl"
+           "scss", "less", "rs", "sass", "styl", "scala", "swift", "ts", \
+           "jade", "gs", "nut", "kt", "kts", "tsx", "fs", "fsi", "fsx", "bsl"
         /\/{2}/
 
       when "latex", "tex", "sty", "cls"


### PR DESCRIPTION
Added MJS support (ECMAScript Modules), which is used for ESM ([node.js documentation](https://nodejs.org/dist/latest-v10.x/docs/api/esm.html))