### PR TITLE
CoffeeScript on NPM has moved to "coffeescript (no hyphen)

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "chai": "~3.5.0",
-    "coffee-script": "~1.12.3",
+    "coffeescript": "~2.3.1",
     "coffeelint": "^1.16.0",
     "coveralls": "^2.11.15",
     "istanbul": "^0.4.5",


### PR DESCRIPTION
Due to some deps we get deprecation warnings about coffeescript and the hyphen in between.
Maybe we could also update to the newest coffeescript version :). I am not a coffeescript user 
so I am not sure if the new milestone version breaks anything. 

Thanks in advance 
Oliver