### PR TITLE
fix for LaTeX regex

### DIFF
--- a/src/sloc.coffee
+++ b/src/sloc.coffee
@@ -38,7 +38,7 @@ getCommentExpressions = (lang) ->
         /\/{2}/
 
       when "latex", "tex", "sty", "cls"
-        start = /\%{2}/
+        start = /\%/
       when "lua", "hs", "sql"
         /--/
       when "erl"


### PR DESCRIPTION
fix for LaTeX regex: latex uses a single `%` for comments, not `%%`. 