### PR TITLE
support include flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Options:
 -h, --help                  output usage information
 -V, --version               output the version number
 -e, --exclude <regex>       regular expression to exclude files and folders
+-i, --include <regex>       regular expression to include files and folders
 -f, --format <format>       format output: json, csv, cli-table
     --format-option [value] add formatter option
 -k, --keys <keys>           report only numbers of the given keys

--- a/src/cli.coffee
+++ b/src/cli.coffee
@@ -55,7 +55,14 @@ filterFiles = (files) ->
     else
       files
 
-  (r.path for r in res)
+  res2 =
+    if programm.include
+      include = new RegExp programm.include
+      res.filter (x) -> include.test x.path
+    else
+      res
+
+  (r.path for r in res2)
 
 options = {}
 fmtOpts = []
@@ -67,6 +74,9 @@ programm
 
   .option '-e, --exclude <regex>',
     'regular expression to exclude files and folders'
+
+  .option '-i, --include <regex>',
+  'regular expression to include files and folders'
 
   .option '-f, --format <format>',
     'format output:' + (" #{k}" for k of fmts).join ','


### PR DESCRIPTION
Simple tweak to support an --include flag, for scenarios where it's preferable to define a regex for files to include rather than exclude.

(In some cases it can be extremely difficult, if not impossible, to define a negative regexp in order to achieve inclusion via clever exclusion.)
