### PR TITLE
Add Ren'Py support in sloc

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ var stats = window.sloc(sourceCode,"javascript");
 - Python
 - R
 - Racket
+- Ren'Py
 - Ruby
 - Rust
 - Scala

--- a/spec/languages.coffee
+++ b/spec/languages.coffee
@@ -44,7 +44,7 @@ module.exports =
       empty: 0
     }
     {
-      names: ["py"]
+      names: ["py", "rpy"]
       code:
         """
           \"""

--- a/spec/languages.coffee
+++ b/spec/languages.coffee
@@ -44,14 +44,14 @@ module.exports =
       empty: 0
     }
     {
-      names: ["py", "rpy"]
+      names: ["py"]
       code:
         """
           \"""
           block comment
           \"""
           # a
-          source.code(); #comment
+          source.code() #comment
 
           # comment
           '''
@@ -64,6 +64,30 @@ module.exports =
       total: 10
       single: 3
       mixed: 1
+      empty: 1
+    }
+    {
+      names: ["rpy"]
+      code:
+        """
+          \"""
+          block comment
+          \"""
+          # a
+          $ source.code() #comment
+          show code #comment
+
+          # comment
+          '''
+          another block comment
+          '''
+        """
+      comment: 10
+      source: 1
+      block: 6
+      total: 11
+      single: 3
+      mixed: 2
       empty: 1
     }
     {

--- a/src/sloc.coffee
+++ b/src/sloc.coffee
@@ -29,7 +29,7 @@ getCommentExpressions = (lang) ->
 
       when "coffee", "iced"
         /\#[^\{]/ # hashtag not followed by opening curly brace
-      when "cr", "py", "ls", "mochi", "nix", "r", "rb", "jl", "pl", "yaml", "hr"
+      when "cr", "py", "ls", "mochi", "nix", "r", "rb", "jl", "pl", "yaml", "hr", "rpy"
         /\#/
       when "js", "jsx", "mjs", "c", "cc", "cpp", "cs", "cxx", "h", "m", "mm", \
            "hpp", "hx", "hxx", "ino", "java", "php", "php5", "go", "groovy", \
@@ -85,7 +85,7 @@ getCommentExpressions = (lang) ->
       start = /\/\*+/
       stop  = /\*\/{1}/
 
-    when "python", "py"
+    when "python", "py", "rpy"
       start = stop = /\"{3}|\'{3}/
 
     when "handlebars", "hbs", "mustache"
@@ -326,6 +326,7 @@ extensions = [
   "r"
   "rb"
   "rkt"
+  "rpy"
   "rs"
   "sass"
   "scala"


### PR DESCRIPTION
Adds support for [Ren'Py](https://renpy.org), a Python-based visual novel engine. Syntax is identical to Python regarding sloc.

Adds a separate module export for `rpy` to note Ren'Py DSL statements which support inline comments. Also removes an illegal `;` from the Python spec.