### PR TITLE
Add pug file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ var stats = window.sloc(sourceCode,"javascript");
 - OCaml
 - Perl 5
 - PHP
+- Pug
 - Python
 - R
 - Racket

--- a/src/sloc.coffee
+++ b/src/sloc.coffee
@@ -34,7 +34,7 @@ getCommentExpressions = (lang) ->
       when "js", "jsx", "mjs", "c", "cc", "cpp", "cs", "cxx", "h", "m", "mm", \
            "hpp", "hx", "hxx", "ino", "java", "php", "php5", "go", "groovy", \
            "scss", "less", "rs", "sass", "styl", "scala", "swift", "ts", \
-           "jade", "gs", "nut", "kt", "kts", "tsx", "fs", "fsi", "fsx", "bsl", \
+           "jade", "pug", "gs", "nut", "kt", "kts", "tsx", "fs", "fsi", "fsx", "bsl", \
            "dart", "agda"
         /\/{2}/
 


### PR DESCRIPTION
Jade was renamed to pug and so was the file extension from .jade to .pug 

This pull request adds the pug file extension while keeping the jade extension for backwards compatibility 