### PR TITLE
Update Everything (almost)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
-  - "4"
-  - "6"
-  - "8"
+  - "12"
+  - "14"
+  - "16"
+  - node

--- a/package.json
+++ b/package.json
@@ -23,18 +23,18 @@
   "license": "MIT",
   "engine": "node",
   "dependencies": {
-    "async": "~2.1.4",
-    "cli-table": "^0.3.1",
-    "commander": "~2.9.0",
+    "async": "^3.2.1",
+    "cli-table": "^0.3.6",
+    "commander": "^8.2.0",
     "readdirp": "^2.1.0"
   },
   "devDependencies": {
-    "chai": "~3.5.0",
-    "coffee-script": "~1.12.3",
-    "coffeelint": "^1.16.0",
-    "coveralls": "^2.11.15",
+    "chai": "^4.3.4",
+    "coffeescript": "^2.6.1",
+    "coffeelint": "^2.1.0",
+    "coveralls": "^3.1.1",
     "istanbul": "^0.4.5",
-    "mocha": "~3.2.0"
+    "mocha": "^9.1.3"
   },
   "repository": {
     "type": "git",
@@ -55,6 +55,6 @@
     "lint": "coffeelint src/",
     "watch": "coffee -o lib -cw src/",
     "prepublish": "coffee -o lib/ -c src/",
-    "test": "npm run lint && mocha --reporter spec --compilers coffee:coffee-script/register --recursive spec/*.spec.coffee"
+    "test": "npm run lint && mocha --require coffeescript/register --recursive spec/*.spec.coffee"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "async": "^3.2.1",
     "cli-table": "^0.3.6",
     "commander": "^8.2.0",
-    "readdirp": "^2.1.0"
+    "readdirp": "^2.2.1"
   },
   "devDependencies": {
     "chai": "^4.3.4",

--- a/src/sloc.coffee
+++ b/src/sloc.coffee
@@ -29,7 +29,8 @@ getCommentExpressions = (lang) ->
 
       when "coffee", "iced"
         /\#[^\{]/ # hashtag not followed by opening curly brace
-      when "cr", "py", "ls", "mochi", "nix", "r", "rb", "jl", "pl", "yaml", "hr", "rpy"
+      when "cr", "py", "ls", "mochi", "nix", "r", \
+           "rb", "jl", "pl", "yaml", "hr", "rpy"
         /\#/
       when "js", "jsx", "mjs", "c", "cc", "cpp", "cs", "cxx", "h", "m", "mm", \
            "hpp", "hx", "hxx", "ino", "java", "php", "php5", "go", "groovy", \


### PR DESCRIPTION
closes #123 (since it has merge issues)
# Changes
## .travis.yml
updated to current + LTS versions
see https://nodejs.org/en/about/releases/

## package.json
Updated all dependencies to the latest version. Except `istanbul` and `readdirp`. Istanbul was deprecated and the new version is called  NYC. I didn't swap it out as I cannot see it being used anywhere. ReadDirP was updated to the newest 2.x version. It wasn't updated to 3.x because the callback API was deprecated. A separate pull request to update the code to use promises or streams is needed.

## src/sloc.coffee
Wrapped a line because the linter was complaining. 

# Tests
two tests fail, but they seem to fail in master aswell
`      2) should support agda`
`      1) should support rpy`

travis fails #127 due to the two errors above