### PR TITLE
fix rpy and agda

### DIFF
--- a/spec/languages.coffee
+++ b/spec/languages.coffee
@@ -83,10 +83,10 @@ module.exports =
           '''
         """
       comment: 10
-      source: 1
+      source: 2
       block: 6
       total: 11
-      single: 3
+      single: 4
       mixed: 2
       empty: 1
     }

--- a/src/sloc.coffee
+++ b/src/sloc.coffee
@@ -29,18 +29,19 @@ getCommentExpressions = (lang) ->
 
       when "coffee", "iced"
         /\#[^\{]/ # hashtag not followed by opening curly brace
-      when "cr", "py", "ls", "mochi", "nix", "r", "rb", "jl", "pl", "yaml", "hr", "rpy"
+      when "cr", "py", "ls", "mochi", "nix", "r", "rb", "jl", "pl", "yaml", \
+      "hr", "rpy"
         /\#/
       when "js", "jsx", "mjs", "c", "cc", "cpp", "cs", "cxx", "h", "m", "mm", \
            "hpp", "hx", "hxx", "ino", "java", "php", "php5", "go", "groovy", \
            "scss", "less", "rs", "sass", "styl", "scala", "swift", "ts", \
            "jade", "gs", "nut", "kt", "kts", "tsx", "fs", "fsi", "fsx", "bsl", \
-           "dart", "agda"
+           "dart"
         /\/{2}/
 
       when "latex", "tex", "sty", "cls"
         start = /\%/
-      when "lua", "hs", "sql"
+      when "lua", "hs", "agda", "sql"
         /--/
       when "erl"
         /\%/
@@ -81,7 +82,7 @@ getCommentExpressions = (lang) ->
     when "js", "jsx", "mjs", "c", "cc", "cpp", "cs", "cxx", "h", "m", "mm", \
          "hpp", "hx", "hxx", "ino", "java", "ls", "nix", "php", "php5", \
          "go", "css", "sass", "scss", "less", "rs", "styl", "scala", "ts", \
-         "gs", "groovy", "nut", "kt", "kts", "tsx", "sql", "dart", "agda"
+         "gs", "groovy", "nut", "kt", "kts", "tsx", "sql", "dart"
       start = /\/\*+/
       stop  = /\*\/{1}/
 
@@ -92,7 +93,7 @@ getCommentExpressions = (lang) ->
       start = /\{\{\!/
       stop = /\}\}/
 
-    when "hs"
+    when "hs", "agda"
       start = /\{-/
       stop  = /-\}/
 


### PR DESCRIPTION
fixes tests failing in #128 

## Agda #116 
This has a similar syntax to haskell and shares the same comments ` ---comment` and `{- multiline -}` , for some reason it's block comment was set up as `/* multiline */`. this makes the tests pass.
https://agda.readthedocs.io/en/latest/language/lexical-structure.html#comments
https://wiki.portal.chalmers.se/agda/ReferenceManual/Comments#:~:text=Agda%20has%20both%20single%2Dline,delimited%20by%20%7B%2D%20and%20%2D%7D%20.

## Ren'py #119 

comment heading here https://www.renpy.org/doc/html/language_basics.html
SDL heading here https://www.renpy.org/doc/html/other.html


The ren py test was just set up wrong
```
        """
          \"""
          block comment
          \"""
          # a
          $ source.code() #comment
          show code #comment
          # comment
          '''
          another block comment
          '''
        """
```
The above has two source lines `$ source.code() #comment` and ` show code #comment` not one. And it has 4 single line comments in

