### PR TITLE
SLOC: make it work on directories

### DIFF
--- a/src/cli.coffee
+++ b/src/cli.coffee
@@ -123,9 +123,10 @@ readSingleFile = (f, done) -> parseFile f, (err, res) ->
 readDir = (dir, done) ->
   processFile = (f, next) -> parseFile (path.join dir, f), next
 
-  readdirp { root: dir, fileFilter: exts }, (err, res) ->
-    return done(err) if err
-    async.mapLimit (filterFiles res.files), 1000, processFile, done
+  readdirp.promise dir, { fileFilter: exts }
+  .then((files) ->  async.mapLimit (filterFiles files), 1000, processFile, done
+  ).catch((err) -> done err)
+
 
 readSource = (p, done) ->
   fs.lstat p, (err, stats) ->


### PR DESCRIPTION
# Updated readdirp compatibility

### Problem
The current version of readdirp in the codebase is 3.3.0. 
However, due to a series of breaking changes readdirp introduced during the transition from version 2.x to 3.x, current implementation does not function as expected when running on directories. However it still works when running on single files. In this PR i aim to restored the functionality.

Example:
```
sloc cli.js ../lib
/Users/domen/.nvm/versions/node/v20.10.0/lib/node_modules/sloc/node_modules/readdirp/index.js:264
    throw new TypeError('readdirp: root argument must be a string. Usage: readdirp(root, options)');
    ^

TypeError: readdirp: root argument must be a string. Usage: readdirp(root, options)
    at readdirp (/Users/domen/.nvm/versions/node/v20.10.0/lib/node_modules/sloc/node_modules/readdirp/index.js:264:11)
    at readDir (/Users/domen/.nvm/versions/node/v20.10.0/lib/node_modules/sloc/lib/cli.js:176:12)
    at /Users/domen/.nvm/versions/node/v20.10.0/lib/node_modules/sloc/lib/cli.js:194:16
    at FSReqCallback.oncomplete (node:fs:200:5)
```

### Solution

In response to this issue, the code has been adapted to ensure compatibility with readdirp version 3.x. The changes align with the specifications outlined in the [readdirp changelog](https://github.com/paulmillr/readdirp/tree/3.3.0?tab=readme-ov-file#changelog).


✅   tests  80 passing (55ms)

✅   linter 

<img width="498" alt="image" src="https://github.com/flosse/sloc/assets/17458685/e610ecee-fc29-4e88-967c-ffbab22900a2">

✅  built and ran the generated cli to verify it now works as expected in comparison to not working before. 
<img width="378" alt="image" src="https://github.com/flosse/sloc/assets/17458685/fead1beb-36c1-40f5-8fca-d1656b2b777a">

<img width="592" alt="image" src="https://github.com/flosse/sloc/assets/17458685/4804ec2b-224f-430d-a615-83748f2bd85b">

<img width="424" alt="image" src="https://github.com/flosse/sloc/assets/17458685/53dff3a2-fe70-4064-a621-3eb2ef47cf00">
