### PR TITLE
Feature/restore back cli options

### DIFF
--- a/src/cli.coffee
+++ b/src/cli.coffee
@@ -123,9 +123,10 @@ readSingleFile = (f, done) -> parseFile f, (err, res) ->
 readDir = (dir, done) ->
   processFile = (f, next) -> parseFile (path.join dir, f), next
 
-  readdirp { root: dir, fileFilter: exts }, (err, res) ->
-    return done(err) if err
-    async.mapLimit (filterFiles res.files), 1000, processFile, done
+  readdirp.promise dir, { fileFilter: exts }
+  .then((files) ->  async.mapLimit (filterFiles files), 1000, processFile, done
+  ).catch((err) -> done err)
+
 
 readSource = (p, done) ->
   fs.lstat p, (err, stats) ->

--- a/src/cli.coffee
+++ b/src/cli.coffee
@@ -40,24 +40,24 @@ parseFile = (f, cb=->) ->
     cb null, res
 
 print = (result, opts, fmtOpts) ->
-  f = programm.format or 'simple'
+  f = programOptions.format or 'simple'
   unless (fmt = fmts[f])?
     return console.error "Error: format #{f} is not supported"
   out = fmt result, opts, fmtOpts
-  out = out.replace colorRegex, '' if programm.stripColors
+  out = out.replace colorRegex, '' if programOptions.stripColors
   console.log out if typeof out is "string"
 
 filterFiles = (files) ->
   res =
-    if programm.exclude
-      exclude = new RegExp programm.exclude
+    if programOptions.exclude
+      exclude = new RegExp programOptions.exclude
       files.filter (x) -> not exclude.test x.path
     else
       files
 
   res2 =
-    if programm.include
-      include = new RegExp programm.include
+    if programOptions.include
+      include = new RegExp programOptions.include
       res.filter (x) -> include.test x.path
     else
       res
@@ -67,7 +67,7 @@ filterFiles = (files) ->
 options = {}
 fmtOpts = []
 programm
-
+  
   .version pkg.version
 
   .usage '[option] <file> | <directory>'
@@ -97,9 +97,10 @@ programm
     'alias custom ext to act like standard ext', object
 
 programm.parse process.argv
+programOptions = programm.opts()
 
-options.keys    = programm.keys
-options.details = programm.details
+options.keys    = programOptions.keys
+options.details = programOptions.details
 options.alias   = programm.alias
 for k of options.alias
   exts.push "*.#{k}"


### PR DESCRIPTION
It seems release is failing due to failing test [here](https://github.com/Homebrew/homebrew-core/actions/runs/7381740793/job/20080671025?pr=158728) https://github.com/Homebrew/homebrew-core/pull/158728

The test is checking if sloc works with csv format option https://github.com/Homebrew/homebrew-core/blob/171e50bca163025fd40fde21629cc667da49c77c/Formula/s/sloc.rb#L23

Options functionality was broken with commander v7.0.0 release. 

## From migration guide for commander lib

Use the .opts() method to access the options. This is available on any command but is used most with the program.
Details: https://github.com/tj/commander.js/releases/tag/v7.0.0


This restores different options functionality. 