### PR TITLE
Add support for the Zig programming language

### DIFF
--- a/spec/languages.coffee
+++ b/spec/languages.coffee
@@ -860,4 +860,28 @@ module.exports =
       mixed: 2
       empty: 1
     }
+     {
+      names: ["zig"]
+      code:
+        """
+          //! this is a top level doc comment
+
+          const print = @import("std").debug.print;
+
+          /// this is a doc comment
+          pub fn main() void {
+
+            //print("Hello?", .{});
+
+            print("Hello, world!", .{}); // another comment
+          }
+        """
+      comment: 4
+      source: 4
+      block: 0
+      single: 4
+      total: 11
+      mixed: 1
+      empty: 4
+    }
   ]

--- a/src/sloc.coffee
+++ b/src/sloc.coffee
@@ -36,7 +36,7 @@ getCommentExpressions = (lang) ->
            "hpp", "hx", "hxx", "ino", "java", "php", "php5", "go", "groovy", \
            "scss", "less", "rs", "sass", "styl", "scala", "swift", "ts", \
            "jade", "pug", "gs", "nut", "kt", "kts", "tsx", \
-           "fs", "fsi", "fsx", "bsl", "dart"
+           "fs", "fsi", "fsx", "bsl", "dart", "zig"
         /\/{2}/
 
       when "latex", "tex", "sty", "cls"
@@ -265,6 +265,7 @@ slocModule = (code, lang, opt={}) ->
 extensions = [
   "agda"
   "asm"
+  "bsl"
   "brs"
   "c"
   "cc"
@@ -315,6 +316,8 @@ extensions = [
   "ls"
   "ml"
   "mli"
+  "m"
+  "mm"
   "mochi"
   "monkey"
   "mustache"
@@ -345,9 +348,7 @@ extensions = [
   "vue"
   "xml"
   "yaml"
-  "m"
-  "mm"
-  "bsl"
+  "zig"
 ]
 
 slocModule.extensions = extensions


### PR DESCRIPTION
Referenced from https://ziglang.org/documentation/master/#Comments

Zig has three comment types all single line (`//` , `///` , `//!`). We can just consider the `//` case as it catches the other two. There are no multiline comments.



I have alphabetized a couple of extensions.